### PR TITLE
Updated scala to 2.11.8 and added cross build for 2.10.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ organization := "com.roundeights"
 
 version := "1.2.0"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
+
+crossScalaVersions := Seq("2.11.8", "2.10.6")
 
 // append -deprecation to the options passed to the Scala compiler
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.2.0"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.10.6")
 
 // append -deprecation to the options passed to the Scala compiler
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
Hello,

I was experimenting in a sbt plugin I'm writing and I had to cross compile to 2.10.

This should not change anything from your point of view and if you could do a +publish, the 2.10 compatible version should be published.

Regards,
Oswaldo
