### PR TITLE
Improve Hash#hex performance.

### DIFF
--- a/src/main/scala/hasher/Hash.scala
+++ b/src/main/scala/hasher/Hash.scala
@@ -16,22 +16,25 @@ object Hash {
 
     /** Implicitly converts from a hash to a byte array */
     implicit def hashToByteArray ( from: Hash ): Array[Byte] = from.bytes
+
+    private[hasher] val HexChars = "0123456789abcdef".toCharArray
 }
+
 
 /**
  * Represents a hash
  */
 case class Hash ( val bytes: Array[Byte] ) extends Equals {
 
+    import Hash._
+
     /** Constructs a hash from a hex string */
     def this ( hex: String ) =
         this( hex.grouped(2).map( Integer.parseInt(_, 16).byteValue ).toArray )
 
-    private[this] val HexChars = "0123456789abcdef".toCharArray
-
     /** Converts this hash to a hex encoded string */
     lazy val hex: String = {
-      val buffer = new StringBuilder
+      val buffer = new StringBuilder(bytes.length * 2)
       bytes.foreach { byte =>
         buffer.append(HexChars((byte & 0xF0) >> 4))
         buffer.append(HexChars(byte & 0x0F))

--- a/src/main/scala/hasher/Hash.scala
+++ b/src/main/scala/hasher/Hash.scala
@@ -27,8 +27,17 @@ case class Hash ( val bytes: Array[Byte] ) extends Equals {
     def this ( hex: String ) =
         this( hex.grouped(2).map( Integer.parseInt(_, 16).byteValue ).toArray )
 
+    private[this] val HexChars = "0123456789abcdef".toCharArray
+
     /** Converts this hash to a hex encoded string */
-    lazy val hex: String = bytes.map( "%02x".format(_) ).mkString("")
+    lazy val hex: String = {
+      val buffer = new StringBuilder
+      bytes.foreach { byte =>
+        buffer.append(HexChars((byte & 0xF0) >> 4))
+        buffer.append(HexChars(byte & 0x0F))
+      }
+      buffer.toString
+    }
 
     /** {@inheritDoc} */
     override def toString: String = hex


### PR DESCRIPTION
Hello.

Current implementation of Hash#hex is very slow.
I improved that performance.

Here is a jmh benchmark results.

Before fix.
```
[info] Running org.openjdk.jmh.Main -i 3 -wi 3 -f1 -t1
[info] # JMH 1.10.3 (released 503 days ago, please consider updating!)
[info] # VM version: JDK 1.8.0_102, VM 25.102-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_102.jdk/Contents/Home/jre/bin/java
[info] # VM options: <none>
[info] # Warmup: 3 iterations, 1 s each
[info] # Measurement: 3 iterations, 1 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: test.roundeights.hasher.HexStringBenchmarkSpec.hex
[info] 
[info] # Run progress: 0.00% complete, ETA 00:00:06
[info] # Fork: 1 of 1
[info] # Warmup Iteration   1: 10.897 ops/ms
[info] # Warmup Iteration   2: 46.537 ops/ms
[info] # Warmup Iteration   3: 53.878 ops/ms
[info] Iteration   1: 53.108 ops/ms
[info] Iteration   2: 44.550 ops/ms
[info] Iteration   3: 55.173 ops/ms
[info] 
[info] 
[info] Result "hex":
[info]   50.944 ±(99.9%) 102.761 ops/ms [Average]
[info]   (min, avg, max) = (44.550, 50.944, 55.173), stdev = 5.633
[info]   CI (99.9%): [≈ 0, 153.704] (assumes normal distribution)
[info] 
[info] 
[info] # Run complete. Total time: 00:00:11
[info] 
[info] Benchmark                    Mode  Cnt   Score     Error   Units
[info] HexStringBenchmarkSpec.hex  thrpt    3  50.944 ± 102.761  ops/ms
```

After fix.
```
[info] Running org.openjdk.jmh.Main -i 3 -wi 3 -f1 -t1
[info] # JMH 1.10.3 (released 503 days ago, please consider updating!)
[info] # VM version: JDK 1.8.0_102, VM 25.102-b14
[info] # VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_102.jdk/Contents/Home/jre/bin/java
[info] # VM options: <none>
[info] # Warmup: 3 iterations, 1 s each
[info] # Measurement: 3 iterations, 1 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: test.roundeights.hasher.HexStringBenchmarkSpec.hex
[info]
[info] # Run progress: 0.00% complete, ETA 00:00:06
[info] # Fork: 1 of 1
[info] # Warmup Iteration   1: 1707.758 ops/ms
[info] # Warmup Iteration   2: 2222.389 ops/ms
[info] # Warmup Iteration   3: 2297.570 ops/ms
[info] Iteration   1: 2605.627 ops/ms
[info] Iteration   2: 2599.048 ops/ms
[info] Iteration   3: 2588.521 ops/ms
[info]
[info]
[info] Result "hex":
[info]   2597.732 ±(99.9%) 157.416 ops/ms [Average]
[info]   (min, avg, max) = (2588.521, 2597.732, 2605.627), stdev = 8.629
[info]   CI (99.9%): [2440.316, 2755.148] (assumes normal distribution)
[info]
[info]
[info] # Run complete. Total time: 00:00:11
[info]
[info] Benchmark                    Mode  Cnt     Score     Error   Units
[info] HexStringBenchmarkSpec.hex  thrpt    3  2597.732 ± 157.416  ops/ms
```
