### PR TITLE
Set UTF-8 as the default character encoding

### DIFF
--- a/src/main/scala/hasher/Digest.scala
+++ b/src/main/scala/hasher/Digest.scala
@@ -208,7 +208,7 @@ private class BCryptDigest (
 
     /** {@inheritDoc} */
     override def add ( bytes: Array[Byte], length: Int ): MutableDigest = {
-        value.append( new String(bytes, 0, length) )
+        value.append( new String(bytes, 0, length, "UTF8") )
         this
     }
 
@@ -251,7 +251,7 @@ private class Pbkdf2Digest (
 
     /** {@inheritDoc} */
     override def add ( bytes: Array[Byte], length: Int ): MutableDigest = {
-        value.append( new String(bytes, 0, length) )
+        value.append( new String(bytes, 0, length, "UTF8") )
         this
     }
 

--- a/src/test/scala/hasher/Helpers.scala
+++ b/src/test/scala/hasher/Helpers.scala
@@ -7,7 +7,7 @@ import com.roundeights.hasher.{Algo, Hasher}
 import java.io.ByteArrayInputStream
 import java.io.StringReader
 
-import scala.io.Source
+import scala.io.{Codec, Source}
 
 /**
  * Basic test data
@@ -184,11 +184,11 @@ case class TestData (
     val bcrypted12: String
 ) {
 
-    def str: String = new String( bytes )
+    def str: String = new String(bytes, "UTF8")
     def builder: StringBuilder = new StringBuilder(str)
     def stream = new ByteArrayInputStream( bytes )
     def reader = new StringReader(str)
-    def source = Source.fromBytes( bytes )
+    def source = Source.fromBytes( bytes )(Codec.UTF8)
 
     def length = str.length
 

--- a/src/test/scala/hasher/TapTest.scala
+++ b/src/test/scala/hasher/TapTest.scala
@@ -3,7 +3,7 @@ package test.roundeights.hasher
 import org.specs2.mutable._
 
 import com.roundeights.hasher.{Algo, Hasher}
-import scala.io.Source
+import scala.io.{Codec, Source}
 
 class TapTest extends Specification {
 
@@ -11,7 +11,7 @@ class TapTest extends Specification {
         "Using " + algo + ", the Tap.hash method" in {
             "Hash a Stream" in {
                 val tap = algo.tap( data.stream )
-                val string = Source.fromInputStream(tap).mkString
+                val string = Source.fromInputStream(tap)(Codec.UTF8).mkString
                 string must_== data.str
                 tap.hash.hex must_== hash
             }
@@ -34,7 +34,7 @@ class TapTest extends Specification {
         "Using " + algo + ", the Tap.hash= method" in {
             "match a Stream" in {
                 val tap = algo.tap( data.stream )
-                val string = Source.fromInputStream(tap).mkString
+                val string = Source.fromInputStream(tap)(Codec.UTF8).mkString
                 string must_== data.str
                 ( tap hash= hash ) must_== true
             }
@@ -59,7 +59,7 @@ class TapTest extends Specification {
         "Using BCrypt, the Tap.hash method" in {
             "Hash a Stream" in {
                 val tap = Algo.bcrypt.tap( data.stream )
-                val string = Source.fromInputStream(tap).mkString
+                val string = Source.fromInputStream(tap)(Codec.UTF8).mkString
                 string must_== data.str
                 tap.hash.hex must beMatching("^[a-zA-Z0-9]{120}$")
             }


### PR DESCRIPTION
The default character encoding for Windows in not UTF-8. This causes failures in
the tests only for this OS.

This is a requirement for #21.