### PR TITLE
 Fixed Hash initialization when hex string has an odd length 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To import Hasher into your project, you just need to add the following
 directives to your `build.sbt` file:
 
 ```
-libraryDependencies ++= Seq("com.roundeights" %% "hasher" % "1.2.0")
+libraryDependencies ++= Seq("com.roundeights" %% "hasher" % "1.2.1")
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "Hasher"
 
 organization := "com.roundeights"
 
-version := "1.2.0"
+version := "1.2.1"
 
 scalaVersion := "2.12.1"
 

--- a/src/main/scala/hasher/Hash.scala
+++ b/src/main/scala/hasher/Hash.scala
@@ -9,7 +9,12 @@ import scala.language.implicitConversions
 object Hash {
 
     /** Constructor...  */
-    def apply ( string: String ) = new Hash(string)
+    def apply ( string: String ): Hash = {
+        // ensure even number of digits
+        val hex = if (string.length % 2 != 0) "0" + string else string
+
+        new Hash(hex.grouped(2).map(Integer.parseInt(_, 16).byteValue).toArray)
+    }
 
     /** Implicitly converts from a hash to a string */
     implicit def hashToString ( from: Hash ): String = from.hex
@@ -26,10 +31,6 @@ object Hash {
  * Represents a hash
  */
 case class Hash ( val bytes: Array[Byte] ) extends Equals {
-
-    /** Constructs a hash from a hex string */
-    def this ( hex: String ) =
-        this( hex.grouped(2).map( Integer.parseInt(_, 16).byteValue ).toArray )
 
     /** Converts this hash to a hex encoded string */
     lazy val hex: String = {

--- a/src/test/scala/hasher/HashTest.scala
+++ b/src/test/scala/hasher/HashTest.scala
@@ -35,6 +35,10 @@ class HashTest extends Specification {
             Hash(md5ed).equals( Hash(md5ed).bytes ) must beTrue
             Hash(md5ed).equals( Hash("ABC123").bytes ) must beFalse
         }
+
+        "initialize from a hex string of even length" in {
+            Hash("98f6bcd4621d373cade4e832627b4f6").bytes mustEqual Hash(md5ed).bytes
+        }
     }
 
 }


### PR DESCRIPTION
the issue exhibits as `Hash("123ff").hex == "123f0f"`